### PR TITLE
Fix printing of response code

### DIFF
--- a/gowebsocket.go
+++ b/gowebsocket.go
@@ -86,7 +86,9 @@ func (socket *Socket) Connect() {
 
 	if err != nil {
 		logger.Error.Println("Error while connecting to server ", err)
-		logger.Error.Println("HTTP Response %d status: %s", resp.StatusCode, resp.Status)
+		if resp != nil {
+			logger.Error.Println("HTTP Response %d status: %s", resp.StatusCode, resp.Status)
+		}
 		socket.IsConnected = false
 		if socket.OnConnectError != nil {
 			socket.OnConnectError(err, *socket)


### PR DESCRIPTION
On some errors, the respoonse code is not set (nil). The commit
02b66393aed7796be8ea6f719b394d48446ad685 introduced printing the content
of the response code which might panic if the response code is nil.